### PR TITLE
Fix asset loading

### DIFF
--- a/assets.lisp
+++ b/assets.lisp
@@ -123,7 +123,7 @@
       (let ((v-arr (make-gpu-array nil :dimensions (length vertices)
                                    :element-type 'assimp-mesh))
             (i-arr (make-gpu-array nil :dimensions (* 3 (length faces))
-                                   :element-type :ushort)))
+                                   :element-type :uint)))
         (with-gpu-array-as-c-array (c-arr i-arr)
           (loop
              :for indices :across faces

--- a/assets.lisp
+++ b/assets.lisp
@@ -109,7 +109,7 @@
             (if tex-file
                 (get-tex
                  (hack-asset-name scene-path tex-file))
-                (get-tex "rust.jpg")))
+                (get-tex "media/rust.jpg")))
            (norm-sampler
             (if norm-file
                 (get-tex

--- a/things.lisp
+++ b/things.lisp
@@ -69,8 +69,8 @@
 
 (defclass box (thing)
   ((stream :initarg :stream)
-   (sampler :initform (get-tex "brickwall.jpg"))
-   (normals :initform (get-tex "brickwall_normal.jpg"))))
+   (sampler :initform (get-tex "media/brickwall.jpg"))
+   (normals :initform (get-tex "media/brickwall_normal.jpg"))))
 
 (defun make-box (pos &optional (size (v! 2 2 2)))
   (check-type pos vec3)
@@ -86,8 +86,8 @@
 
 (defclass ball (thing)
   ((stream :initarg :stream)
-   (sampler :initform (get-tex "brickwall.jpg"))
-   (normals :initform (get-tex "brickwall_normal.jpg"))
+   (sampler :initform (get-tex "media/brickwall.jpg"))
+   (normals :initform (get-tex "media/brickwall_normal.jpg"))
    (id :initform (incf *creature-id*))))
 
 


### PR DESCRIPTION
Look for images in `media/`
Increased indices array to hold `:uint`, so we can load [more complex assets](https://sketchfab.com/3d-models/apollo-11-command-module-combined-372bb6781922471cada4e0a9bd5c61fb).