### PR TITLE
Use (cepl-context) instead of *cepl-context

### DIFF
--- a/play-with-verts.lisp
+++ b/play-with-verts.lisp
@@ -19,7 +19,7 @@
 
     ;; set the position of our viewport
     (setf (resolution (current-viewport))
-          (surface-resolution (current-surface *cepl-context*)))
+          (surface-resolution (current-surface (cepl-context))))
 
     ;; clear the default fbo
     (clear)


### PR DESCRIPTION
*cepl-context* is not defined. I guess obsolete and it should be (cepl-context)